### PR TITLE
Save post date if post if published directly #1066

### DIFF
--- a/blog.py
+++ b/blog.py
@@ -174,10 +174,10 @@ class BlogPost(Workflow, ModelSQL, ModelView):
                 'uri': uri,
                 'content': post_form.content.data,
                 'nereid_user': request.nereid_user.id,
-                'state': 'Published' if post_form.publish.data else 'Draft',
                 'allow_guest_comments': post_form.allow_guest_comments.data,
             })
             if post_form.publish.data:
+                self.publish([post_id])
                 flash('Your post has been published.')
             else:
                 flash('Your post has been saved.')


### PR DESCRIPTION
If the post is directly published without being saved as draft,
then the post date is not saved.
This patch fixes and tests this issue

Review: 9904040
